### PR TITLE
Adds excerpt for posts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,6 +190,7 @@ pub mod libkhata {
         filename: String,
         author: String,
         body: String,
+        excerpt: String,
         hash: String,
         date: DateTime<Local>,
         sdate: String,
@@ -207,6 +208,7 @@ pub mod libkhata {
         filename: String,
         author: String,
         body: String,
+        excerpt: String,
         hash: String,
         sdate: String,
         tags: HashMap<String, String>,
@@ -221,6 +223,7 @@ pub mod libkhata {
                 title: post.title.clone(),
                 slug: post.slug.clone(),
                 body: post.body.clone(),
+                excerpt: post.excerpt.clone(),
                 filename: post.filename.clone(),
                 hash: post.hash.clone(),
                 sdate: post.sdate.clone(),
@@ -355,10 +358,15 @@ pub mod libkhata {
         let result = hasher.result();
         let hashs = hex::encode(&result[..]);
 
+        // Find excerpt <!-- excerpt -->
+        let excerpt_index = html_output.find("<!-- excerpt -->").unwrap_or(0);
+        let excerpt: String = html_output.drain(..excerpt_index).collect();
+
         let post = Post {
             title,
             slug: slug.clone(),
             body: html_output,
+            excerpt,
             filename,
             hash: hashs,
             date: dt,
@@ -607,6 +615,7 @@ pub mod libkhata {
             title: post.title.clone(),
             slug: post.slug.clone(),
             body: post.body.clone(),
+            excerpt: post.excerpt.clone(),
             filename: post.filename.clone(),
             hash: post.hash.clone(),
             sdate: post.sdate.clone(),

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,7 +15,16 @@
         Posted: {{ post.sdate }}
     </small>
     <hr>
-    {{ post.body | safe }}
+    {% if post.excerpt %}
+        {{ post.excerpt | safe }}
+        {% if main %}
+        <strong><a href="posts/{{ post.slug }}.html">Read more</a></strong>
+        {% else %}
+        <strong><a href="posts/{{ post.slug }}.html">Read more</a></strong>
+        {% endif %}
+    {% else %}
+        {{ post.body | safe }}
+    {% endif %}
 
 </div>
 {% endfor %}


### PR DESCRIPTION
A section can be marked as excerpt in a post by mentioning
<!-- excerpt --> at the end of it. There can be only one excerpt
section. This mainly helps, if you want to show excerpt instead
of the entire blog post in the blog listing page.